### PR TITLE
Add option for keybind to close an open terminal window

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ require("luxterm").setup({
     toggle_manager = "<C-/>",     -- Toggle session manager
     next_session = "<C-k>",       -- Next session keybinding
     prev_session = "<C-j>",       -- Previous session keybinding
+    hide_terminal = "<C-Esc>",    -- Hide active terminal keybinding
     global_session_nav = false,   -- Enable global session navigation
   }
 })
@@ -142,7 +143,7 @@ When a terminal session window is open:
 
 | Key | Action |
 |-----|--------|
-| `<C-Esc>` | Close the session window (terminal mode) |
+| Hide key (default `<C-Esc>`) | Close the session window (terminal mode) |
 | Toggle key (default `<C-/>`) | Toggle session manager (normal/terminal mode) |
 
 ---

--- a/lua/luxterm/config.lua
+++ b/lua/luxterm/config.lua
@@ -14,6 +14,7 @@ M.defaults = {
     toggle_manager = "<C-/>",
     next_session = "<C-k>",
     prev_session = "<C-j>",
+    hide_terminal = "<C-Esc>",
     global_session_nav = false
   }
 }

--- a/lua/luxterm/core.lua
+++ b/lua/luxterm/core.lua
@@ -773,7 +773,10 @@ function M.open_session_window(session)
   end
   
   floating_window.create_session_window(session, {
-    auto_hide = get_config("auto_hide")
+    auto_hide = get_config("auto_hide"),
+    keymaps = {
+      hide_terminal = get_config("keymaps").hide_terminal
+    }
   })
   
   -- Ensure terminal keymaps are set up for this session

--- a/lua/luxterm/ui/floating_window.lua
+++ b/lua/luxterm/ui/floating_window.lua
@@ -88,7 +88,6 @@ function M.create_window(config)
   
   -- Create window
   local winid = vim.api.nvim_open_win(bufnr, config.enter or false, win_config)
-  M.winid = winid
   
   vim.wo[winid].winhighlight = WINHIGHLIGHT
 

--- a/lua/luxterm/ui/floating_window.lua
+++ b/lua/luxterm/ui/floating_window.lua
@@ -88,6 +88,7 @@ function M.create_window(config)
   
   -- Create window
   local winid = vim.api.nvim_open_win(bufnr, config.enter or false, win_config)
+  M.winid = winid
   
   vim.wo[winid].winhighlight = WINHIGHLIGHT
 
@@ -344,7 +345,7 @@ function M.create_session_window(session, config)
       
       -- Don't map ESC at all - let it pass through to the terminal application
       -- Use C-Esc to close terminal window from terminal mode
-      vim.keymap.set("t", "<C-Esc>", function()
+      vim.keymap.set("t", config.keymaps.hide_terminal or "<C-ESC>", function()
         M.close_window(winid)
       end, opts)
       


### PR DESCRIPTION
I've been frustrated by the inability to change the C-Esc keybind for closing the active terminal. This pull request adds a config option to allow this.