### PR TITLE
feat: Add an option (session_as_buffer) to control session buffer wr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ require("luxterm").setup({
   
   -- Auto-hide floating windows when cursor leaves
   auto_hide = true,
+
+  -- List terminal buffers in :buffers, BufferLine, etc. (false = scratch only)
+  session_as_buffer = true,
   
   -- Keybinding configuration
   keymaps = {

--- a/lua/luxterm/config.lua
+++ b/lua/luxterm/config.lua
@@ -10,6 +10,7 @@ M.defaults = {
   preview_enabled = true,
   focus_on_create = false,
   auto_hide = true,
+  session_as_buffer = true,
   keymaps = {
     toggle_manager = "<C-/>",
     next_session = "<C-k>",
@@ -26,6 +27,7 @@ M.schema = {
   preview_enabled = "boolean",
   focus_on_create = "boolean",
   auto_hide = "boolean",
+  session_as_buffer = "boolean",
   keymaps = "table"
 }
 

--- a/lua/luxterm/core.lua
+++ b/lua/luxterm/core.lua
@@ -625,7 +625,8 @@ function M.create_session(opts)
   
   local session = session_manager.create_session({
     name = opts.name,
-    activate = opts.activate
+    activate = opts.activate,
+    session_as_buffer = get_config("session_as_buffer")
   })
   
   events.emit(events.SESSION_CREATED, {session = session})

--- a/lua/luxterm/session_manager.lua
+++ b/lua/luxterm/session_manager.lua
@@ -225,7 +225,8 @@ function M.create_session(opts)
   
   local bufnr = opts.bufnr
   if not bufnr then
-    bufnr = vim.api.nvim_create_buf(true, false)
+    local listed = opts.session_as_buffer ~= false
+    bufnr = vim.api.nvim_create_buf(listed, not listed)
 
     local win_config = {
       relative = "editor",


### PR DESCRIPTION
…iting

Add a new configuration option `session_as_buffer` (default true) to control whether session output is written to the buffer. When disabled, sessions are only displayed in the built-in control panel, and will not appear in buffer listings such as BufferLine or
FzfLua buffers like open files.